### PR TITLE
Fix Grin package paths

### DIFF
--- a/tools/echo.lua
+++ b/tools/echo.lua
@@ -1,4 +1,4 @@
-local argparse = grin.getPackageAPI("ElvishJerricco/Grin", "argparse")
+local argparse = grin.getPackageAPI("Team-CC-Corp/Grin", "argparse")
 
 local parser = argparse.new()
 parser

--- a/tools/glep.lua
+++ b/tools/glep.lua
@@ -1,4 +1,4 @@
-local argparse = grin.getPackageAPI("ElvishJerricco/Grin", "argparse")
+local argparse = grin.getPackageAPI("Team-CC-Corp/Grin", "argparse")
 
 local parser = argparse.new()
 parser

--- a/tools/list.lua
+++ b/tools/list.lua
@@ -1,4 +1,4 @@
-local argparse = grin.getPackageAPI("ElvishJerricco/Grin", "argparse")
+local argparse = grin.getPackageAPI("Team-CC-Corp/Grin", "argparse")
 
 local parser = argparse.new()
 parser

--- a/tools/test.lua
+++ b/tools/test.lua
@@ -1,4 +1,4 @@
-local argparse = grin.getPackageAPI("ElvishJerricco/Grin", "argparse")
+local argparse = grin.getPackageAPI("Team-CC-Corp/Grin", "argparse")
 
 local parser = argparse.new()
 parser

--- a/tools/xargs.lua
+++ b/tools/xargs.lua
@@ -1,4 +1,4 @@
-local argparse = grin.getPackageAPI("ElvishJerricco/Grin", "argparse")
+local argparse = grin.getPackageAPI("Team-CC-Corp/Grin", "argparse")
 
 local parser = argparse.new()
 parser


### PR DESCRIPTION
Grin has been moved to Team-CC Corp. This fixes the packages not being found.
