### PR TITLE
Fix list program

### DIFF
--- a/tools/list.lua
+++ b/tools/list.lua
@@ -30,7 +30,7 @@ for i,dir in ipairs(options.dirs) do
         end
 
         local tDirs, tFiles = {}, {}
-        for i,entry in ipairs(fs.list(shell.resolve(dir))) do
+        for i,entry in ipairs(fs.list(dir)) do
             if entry:sub(1,1) ~= "." or options.a then
                 if fs.isDir(fs.combine(dir, entry)) then
                     table.insert(tDirs, entry)
@@ -52,7 +52,7 @@ for i,dir in ipairs(options.dirs) do
         end
     else
         local tDir = {}
-        for i,entry in ipairs(fs.list(shell.resolve(dir))) do
+        for i,entry in ipairs(fs.list(dir)) do
             if entry:sub(1,1) ~= "." or options.a then
                 table.insert(tDir, entry)
             end


### PR DESCRIPTION
Paths were resolved twice, so the directory wasn't found. List wasn't used until e15358d5aa3ec070cafc377c6eb80b579f4403d2 so that is why it hasn't been picked up on before.
