### PR TITLE
Add extra settings features (#5)

### DIFF
--- a/lib/buffer.lua
+++ b/lib/buffer.lua
@@ -1,4 +1,4 @@
-function new(original)
+function new(original, settings)
 	if not original then original = term.current() end
 	local text = {}
 	local textColor = {}
@@ -20,7 +20,7 @@ function new(original)
 	local bubble = false
 	local friendlyClear = false
 	local original = original
-	local maxScrollback = 100
+	local maxScrollback = settings and settings.maxScrollback or 100
 
 	local redirect = {}
 


### PR DESCRIPTION
- Max scrollback
- Max history length
- Colors
- Directory
- Relocate history to a `.clam.history` file

The settings files look like:

``` lua
{
  dir = "",
  aliases = {
    grep = "glep",
  },
  env = {
    HOME = "/me",
  },
  colors = {
    prompt = "magenta"
  },
  maxScrollback = 200,
  maxHistory = 1000,
}
```
